### PR TITLE
get current cases via api proxy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,8 @@
   for = "/*"
   [headers.values]
     Access-Control-Allow-Origin = "*"
+[[redirects]]
+  from = "/v2/cases/*"
+  to = "https://covidapi.info/api/v1/:splat"
+  status = 200
+  force = true


### PR DESCRIPTION
Use proxied requests to https://covidapi.info/ (https://github.com/backtrackbaba/covid-api) and therefore JHU data to provide case numbers by country

See https://documenter.getpostman.com/view/2568274/SzS8rjbe?version=latest for API docs

Example request: https://deploy-preview-10--coverified-data.netlify.com/v2/cases/country/DEU/latest

closes #2 